### PR TITLE
ci: test building debs

### DIFF
--- a/.github/pythonchecks.txt
+++ b/.github/pythonchecks.txt
@@ -22,3 +22,9 @@ flake8-noqa==1.3.2
 coverage==7.3.2
 setuptools==68.2.2; python_version == '3.12'
 build==1.2.1
+requests==2.28.1; python_version == '3.11'
+requests==2.31.0; python_version >= '3.12'
+filelock==3.9.0; python_version == '3.11'
+filelock==3.14.0; python_version >= '3.12'
+internetarchive==3.3.0; python_version == '3.11'
+internetarchive==3.7.0; python_version >= '3.12'

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -44,7 +44,6 @@ jobs:
           pyproject-build --wheel --outdir dist .
           cd dist
           pip wheel langcodes
-          rm charset_*
      - name: wheel2deb
        run: |
           cd dist

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -78,7 +78,8 @@ jobs:
           ls
           wheel2deb
           ls
-          wheel2deb build
+          ls output
+          wheel2deb build output
      - name: show off
        run: |
           ls -l output/*.deb

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -43,7 +43,7 @@ jobs:
        run: |
           pyproject-build --wheel --outdir dist .
           cd dist
-          pip wheel langcodes==3.4.0 --no-deps
+          pip wheel langcodes==3.3.0 --no-deps
      - name: wheel2deb
        run: |
           cd dist

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -75,18 +75,12 @@ jobs:
      - name: wheel2deb
        run: |
           cd dist
-          ls
-          wheel2deb --help
           wheel2deb
-          ls
-          ls output
-          wheel2deb build --help
-          wheel2deb build
      - name: show off
        run: |
           cd dist
           ls -l output/*.deb
-          dpkg -i output/*.deb
+          sudo dpkg -i output/*.deb
     
     
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -67,7 +67,8 @@ jobs:
         pip install build wheel2deb
      - name: Build wheel
        run: |
-          ls && pyproject-build --wheel --outdir dist .
+          ls
+          pyproject-build --wheel --outdir dist .
           cd dist
           pip wheel MW_SRE_Utils-3.0-py3-none-any.whl
      - name: wheel2deb

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -55,6 +55,32 @@ jobs:
       - name: Publish to PyPi
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@v1.9.0
+  deb:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+     - name: Install requirements
+       run: |
+        sudo apt install -y python3-requests python3-filelock
+        sudo apt install -y python3-apt apt-file dpkg-dev fakeroot build-essential devscripts debhelper
+        sudo apt-file update
+        pip install build wheel2deb
+     - name: Build wheel
+       run: |
+          cd modules/mediawiki/files/bin
+          pyproject-build --wheel --outdir dist .
+          cd dist
+          pip wheel MW_SRE_Utils-3.0-py3-none-any.whl
+     - name: wheel2deb
+       run: |
+          wheel2deb
+          wheel2deb build
+     - name: show off
+       run: |
+          ls -l output/*.deb
+          dpkg -i output/*.deb
+    
+    
 
   notify-irc:
     needs: build

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -28,7 +28,7 @@ jobs:
           flake8 --exclude=*/__init__.py,dist/*,build/* --ignore=E501,W503,SFS301,T003,PT009
           coverage run --branch -m pytest tests
           mypy miraheze --ignore-missing-imports
-   deb:
+  deb:
     needs: build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -74,7 +74,7 @@ jobs:
           pip wheel *.whl
      - name: wheel2deb
        run: |
-          ls
+          cd dist
           wheel2deb
           wheel2deb build
      - name: show off

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -35,7 +35,7 @@ jobs:
      - uses: actions/checkout@v4
      - name: Install requirements
        run: |
-        sudo apt install -y python3-requests python3-filelock
+        sudo apt install -y python3-requests python3-filelock python3-internetarchive
         sudo apt install -y python3-apt apt-file dpkg-dev fakeroot build-essential devscripts debhelper
         sudo apt-file update
         pip install build wheel2deb
@@ -43,7 +43,7 @@ jobs:
        run: |
           pyproject-build --wheel --outdir dist .
           cd dist
-          pip wheel *.whl
+          pip wheel langcodes
           rm charset_*
      - name: wheel2deb
        run: |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -43,7 +43,7 @@ jobs:
        run: |
           pyproject-build --wheel --outdir dist .
           cd dist
-          pip wheel langcodes
+          pip wheel langcodes --no-deps
      - name: wheel2deb
        run: |
           cd dist

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -44,6 +44,7 @@ jobs:
           pyproject-build --wheel --outdir dist .
           cd dist
           pip wheel *.whl
+          rm charset_*
      - name: wheel2deb
        run: |
           cd dist

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -76,12 +76,15 @@ jobs:
        run: |
           cd dist
           ls
+          wheel2deb --help
           wheel2deb
           ls
           ls output
-          wheel2deb build output
+          wheel2deb build --help
+          wheel2deb build
      - name: show off
        run: |
+          cd dist
           ls -l output/*.deb
           dpkg -i output/*.deb
     

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -67,7 +67,7 @@ jobs:
         pip install build wheel2deb
      - name: Build wheel
        run: |
-          pyproject-build --wheel --outdir dist .
+          ls && pyproject-build --wheel --outdir dist .
           cd dist
           pip wheel MW_SRE_Utils-3.0-py3-none-any.whl
      - name: wheel2deb

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -59,6 +59,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
+     - uses: actions/checkout@v4
      - name: Install requirements
        run: |
         sudo apt install -y python3-requests python3-filelock

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -67,7 +67,6 @@ jobs:
         pip install build wheel2deb
      - name: Build wheel
        run: |
-          cd modules/mediawiki/files/bin
           pyproject-build --wheel --outdir dist .
           cd dist
           pip wheel MW_SRE_Utils-3.0-py3-none-any.whl

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -71,7 +71,7 @@ jobs:
           ls
           pyproject-build --wheel --outdir dist .
           cd dist
-          pip wheel MW_SRE_Utils-3.0-py3-none-any.whl
+          pip wheel *.whl
      - name: wheel2deb
        run: |
           wheel2deb

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -28,34 +28,7 @@ jobs:
           flake8 --exclude=*/__init__.py,dist/*,build/* --ignore=E501,W503,SFS301,T003,PT009
           coverage run --branch -m pytest tests
           mypy miraheze --ignore-missing-imports
-  
-  deploy:
-    runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/p/Miraheze_PyUtils
-    permissions:
-      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.12.1
-        with:
-          access_token: ${{ github.token }}
-      - uses: actions/checkout@v4
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.11
-      - name: Install pypa/build
-        run: |
-          python -m pip install --upgrade pip wheel
-          pip install -r .github/pythonchecks.txt
-      - name: Build a binary wheel
-        run: pyproject-build --wheel --outdir dist .
-      - name: Publish to PyPi
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@v1.9.0
-  deb:
+   deb:
     needs: build
     runs-on: ubuntu-latest
     steps:
@@ -81,11 +54,39 @@ jobs:
           ls -l output/*.deb
           sudo dpkg -i output/*.deb
           apt show python3-miraheze-pyutils
+          
+  deploy:
+    needs: deb
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/Miraheze_PyUtils
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.12.1
+        with:
+          access_token: ${{ github.token }}
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+      - name: Install pypa/build
+        run: |
+          python -m pip install --upgrade pip wheel
+          pip install -r .github/pythonchecks.txt
+      - name: Build a binary wheel
+        run: pyproject-build --wheel --outdir dist .
+      - name: Publish to PyPi
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@v1.9.0
     
     
 
   notify-irc:
-    needs: build
+    needs: deb
     runs-on: ubuntu-latest
     if: ${{ always() && github.repository_owner == 'miraheze' && ( github.ref == 'refs/heads/master' || github.event_name == 'pull_request' ) }}
     steps:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -60,6 +60,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
      - uses: actions/checkout@v4
+     - name: Install Python
+       uses: actions/setup-python@v5
+       with:
+          python-version: 3.11
      - name: Install requirements
        run: |
         sudo apt install -y python3-requests python3-filelock

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -75,7 +75,9 @@ jobs:
      - name: wheel2deb
        run: |
           cd dist
+          ls
           wheel2deb
+          ls
           wheel2deb build
      - name: show off
        run: |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -60,10 +60,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
      - uses: actions/checkout@v4
-     - name: Install Python
-       uses: actions/setup-python@v5
-       with:
-          python-version: 3.11
      - name: Install requirements
        run: |
         sudo apt install -y python3-requests python3-filelock

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -74,6 +74,7 @@ jobs:
           pip wheel *.whl
      - name: wheel2deb
        run: |
+          ls
           wheel2deb
           wheel2deb build
      - name: show off

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -43,7 +43,7 @@ jobs:
        run: |
           pyproject-build --wheel --outdir dist .
           cd dist
-          pip wheel langcodes --no-deps
+          pip wheel langcodes==3.4.0 --no-deps
      - name: wheel2deb
        run: |
           cd dist

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -68,7 +68,6 @@ jobs:
         pip install build wheel2deb
      - name: Build wheel
        run: |
-          ls
           pyproject-build --wheel --outdir dist .
           cd dist
           pip wheel *.whl
@@ -81,6 +80,7 @@ jobs:
           cd dist
           ls -l output/*.deb
           sudo dpkg -i output/*.deb
+          apt show python3-miraheze-pyutils
     
     
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,4 @@
-requests==2.28.1; python_version == '3.11'
-requests==2.31.0; python_version >= '3.12'
-filelock==3.9.0; python_version == '3.11'
-filelock==3.14.0; python_version >= '3.12'
+requests
+filelock
 langcodes==3.3.0
-internetarchive==3.3.0; python_version == '3.11'
-internetarchive==3.7.0; python_version >= '3.12'
+internetarchive

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests
 filelock
-langcodes==3.3.0
+langcodes==3.4.0
 internetarchive

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests
 filelock
-langcodes==3.4.0
+langcodes==3.3.0
 internetarchive

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ classifiers =
     Topic :: System :: Systems Administration
     Topic :: Utilities
 [options]
-python_requires = >=3.11
+python_requires = >=3.10
 [options.entry_points]
 console_scripts =
     partial-reset-wiki = miraheze.salt.mwcli.partial_reset_wiki:main

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,7 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new job to GitHub Actions workflow for building and displaying Debian packages from Python wheels.

- **Dependency Updates**
  - Updated `requests`, `filelock`, and `internetarchive` package versions for Python 3.12 and above in dependency checks.
  - Removed strict version constraints for `requests`, `filelock`, and `internetarchive` in `requirements.txt`.

- **Compatibility**
  - Lowered `python_requires` version constraint from `>=3.11` to `>=3.10` in `setup.cfg`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->