### PR TITLE
fix_container_permissions: update version

### DIFF
--- a/miraheze/swift/fix_container_permissions.py
+++ b/miraheze/swift/fix_container_permissions.py
@@ -4,12 +4,12 @@ import argparse
 
 
 def fix_container_perms(wiki: str) -> None:
-    out = subprocess.run(['sudo', '-u', 'www-data', 'php', '/srv/mediawiki/1.41/maintenance/run.php', '/srv/mediawiki/1.41/extensions/CreateWiki/maintenance/setContainersAccess.php', '--wiki', wiki], capture_output=True, text=True)
+    out = subprocess.run(['sudo', '-u', 'www-data', 'php', '/srv/mediawiki/1.42/maintenance/run.php', '/srv/mediawiki/1.42/extensions/CreateWiki/maintenance/setContainersAccess.php', '--wiki', wiki], capture_output=True, text=True)
     matches = re.findall(r"Making sure 'mwstore:\/\/miraheze-swift\/([^']+)' [^\n]+\.failed\.", out.stdout)
     for match in matches:
         subprocess.run(['swift', 'post', '--read-acl', 'mw:media', '--write-acl', 'mw:media', f'miraheze-{wiki}-{match}'], check=True)
 
-    subprocess.run(['sudo', '-u', 'www-data', 'php', '/srv/mediawiki/1.41/maintenance/run.php', '/srv/mediawiki/1.41/extensions/CreateWiki/maintenance/setContainersAccess.php', '--wiki', wiki])
+    subprocess.run(['sudo', '-u', 'www-data', 'php', '/srv/mediawiki/1.42/maintenance/run.php', '/srv/mediawiki/1.42/extensions/CreateWiki/maintenance/setContainersAccess.php', '--wiki', wiki])
 
 
 def main() -> None:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated paths for maintenance scripts to be compatible with MediaWiki version 1.42, ensuring correct execution of container access permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->