### PR TITLE
Add a tool to automate imports

### DIFF
--- a/miraheze/mediawiki/mwimport.py
+++ b/miraheze/mediawiki/mwimport.py
@@ -6,7 +6,7 @@ import subprocess
 import sys
 
 
-def parse_args(args: list | None = None, check_paths: bool = True) -> argparse.Namespace:
+def parse_args(input_args: list | None = None, check_paths: bool = True) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="A script to automate manual wiki imports")
     parser.add_argument(
         "--no-log", dest="nolog", action="store_true",
@@ -30,7 +30,7 @@ def parse_args(args: list | None = None, check_paths: bool = True) -> argparse.N
     )
     parser.add_argument("wiki", help="Database name of the wiki to import to")
 
-    args = parser.parse_args(args)
+    args = parser.parse_args(input_args)
     if not args.xml and not args.images:
         raise ValueError("--xml and/or --images must be passed")
     if args.images and not args.images_comment:

--- a/miraheze/mediawiki/mwimport.py
+++ b/miraheze/mediawiki/mwimport.py
@@ -96,7 +96,7 @@ def run_scripts(args: argparse.Namespace, scripts: list[list[str]]) -> int:
         print(f'Running {shlex.join(script)}')
         if not args.nolog:
             print('Logging execution...')
-            log(shlex.join(script))
+            log(f"{shlex.join(script)} (START)")
 
         proc = subprocess.run(script)
 
@@ -132,7 +132,7 @@ def run():
 
     if not args.nolog:
         print('Logging start...')
-        log(f'Starting import for {args.wiki} (XML: {args.xml}; Images: {args.images})')
+        log(f'Starting import for {args.wiki} (XML: {args.xml}; Images: {args.images}) (START)')
 
     return_code = run_scripts(args, scripts)
 

--- a/miraheze/mediawiki/mwimport.py
+++ b/miraheze/mediawiki/mwimport.py
@@ -125,9 +125,8 @@ def run():
     print("Will run:")
     for script in scripts:
         print(f"* {shlex.join(script)}")
-    if not args.confirm:
-        if input("Type 'Y' to confirm: ").upper() != "Y":
-            return 1
+    if not args.confirm and input("Type 'Y' to confirm: ").upper() != "Y":
+        return 1
 
     if not args.nolog:
         print("Logging start...")

--- a/miraheze/mediawiki/mwimport.py
+++ b/miraheze/mediawiki/mwimport.py
@@ -96,7 +96,7 @@ def run_scripts(args: argparse.Namespace, scripts: list[list[str]]) -> int:
         print(f'Running {shlex.join(script)}')
         if not args.nolog:
             print('Logging execution...')
-            log(f"{shlex.join(script)} (START)")
+            log(f'{shlex.join(script)} (START)')
 
         proc = subprocess.run(script)
 

--- a/miraheze/mediawiki/mwimport.py
+++ b/miraheze/mediawiki/mwimport.py
@@ -121,7 +121,10 @@ def run():
 
     scripts = get_scripts(args)
     scripts = [
-        ['sudo', '-u', 'www-data', 'php', f'/srv/mediawiki/{version}/maintenance/run.php', f'--wiki={args.wiki}', *script] for script in scripts
+        # This is a hack to squeeze the --wiki argument after the script name, but before any of the other arguments
+        # (adding --wiki to every script manually is kinda clutters the whole list since most maintenance scripts
+        # run on a single wiki, and all of the ones used here also run on a single wiki)
+        ['sudo', '-u', 'www-data', 'php', f'/srv/mediawiki/{version}/maintenance/run.php', script[0], f'--wiki={args.wiki}', *script[1:]] for script in scripts
     ]
 
     print('Will run:')

--- a/miraheze/mediawiki/mwimport.py
+++ b/miraheze/mediawiki/mwimport.py
@@ -5,20 +5,29 @@ import shlex
 import subprocess
 import sys
 
+
 def parse_args(args: list | None = None, check_paths: bool = True) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="A script to automate manual wiki imports")
-    parser.add_argument("--no-log", dest="nolog", action="store_true",
-        help="Whether or not to disable logging to the server admin log")
-    parser.add_argument("--confirm", "--yes", "-y", dest="confirm", action="store_true",
-        help="Whether or not to skip the initial confirmation prompt")
+    parser.add_argument(
+        "--no-log", dest="nolog", action="store_true",
+        help="Whether or not to disable logging to the server admin log",
+    )
+    parser.add_argument(
+        "--confirm", "--yes", "-y", dest="confirm", action="store_true",
+        help="Whether or not to skip the initial confirmation prompt",
+    )
     parser.add_argument("--version", help="MediaWiki version to use (automatically detected if not passed)")
     parser.add_argument("--xml", help="XML file to import")
     parser.add_argument("--username-prefix", help="Interwiki prefix for importing XML")
     parser.add_argument("--images", help="Directory of images to import")
-    parser.add_argument("--images-comment", help="The comment passed to importImages.php"
-        " (example: 'Importing images from https://example.com ([[phorge:T1234|T1234]])')")
-    parser.add_argument("--search-recursively", action="store_true",
-        help="Whether or not to pass --search-recursively (check files in subdirectories) to importImages.php")
+    parser.add_argument(
+        "--images-comment", help="The comment passed to importImages.php"
+        " (example: 'Importing images from https://example.com ([[phorge:T1234|T1234]])')",
+    )
+    parser.add_argument(
+        "--search-recursively", action="store_true",
+        help="Whether or not to pass --search-recursively (check files in subdirectories) to importImages.php",
+    )
     parser.add_argument("wiki", help="Database name of the wiki to import to")
 
     args = parser.parse_args(args)
@@ -39,11 +48,13 @@ def parse_args(args: list | None = None, check_paths: bool = True) -> argparse.N
 
     return args
 
+
 def log(message: str):
     subprocess.run(
         ["/usr/local/bin/logsalmsg", message],
         check=True,
     )
+
 
 def get_version(wiki: str) -> str:
     return subprocess.run(
@@ -52,6 +63,7 @@ def get_version(wiki: str) -> str:
         check=True,
         text=True,
     ).stdout.strip()
+
 
 def get_scripts(args: argparse.Namespace) -> list[list[str]]:
     scripts = []
@@ -76,6 +88,7 @@ def get_scripts(args: argparse.Namespace) -> list[list[str]]:
 
     return scripts
 
+
 def run_scripts(args: argparse.Namespace, scripts: list[list[str]]) -> int:
     for script in scripts:
         print(f"Running {shlex.join(script)}")
@@ -93,6 +106,7 @@ def run_scripts(args: argparse.Namespace, scripts: list[list[str]]) -> int:
             return proc.returncode
 
     return 0
+
 
 def run():
     try:
@@ -126,6 +140,7 @@ def run():
         log(f"Finished import for {args.wiki} (XML: {args.xml}; Images: {args.images}) (END - exit={return_code})")
 
     return return_code
+
 
 if __name__ == "__main__":
     sys.exit(run())

--- a/miraheze/mediawiki/mwimport.py
+++ b/miraheze/mediawiki/mwimport.py
@@ -98,7 +98,12 @@ def run_scripts(args: argparse.Namespace, scripts: list[list[str]]) -> int:
             print('Logging execution...')
             log(f'{shlex.join(script)} (START)')
 
-        proc = subprocess.run(script)
+        proc = subprocess.Popen(script)
+        try:
+            proc.wait()
+        except KeyboardInterrupt:
+            proc.terminate()
+            proc.wait()
 
         if not args.nolog:
             print('Logging execution end...')

--- a/miraheze/mediawiki/mwimport.py
+++ b/miraheze/mediawiki/mwimport.py
@@ -69,15 +69,17 @@ def get_scripts(args: argparse.Namespace) -> list[list[str]]:
     scripts = []
 
     if args.xml:
-        script = ["importDump", args.xml, "--no-updates"]
+        script = ["importDump", "--no-updates"]
         if args.username_prefix:
             script.append(f"--username-prefix={args.username_prefix}")
+        script.extend(["--", args.xml])
         scripts.append(script)
 
     if args.images:
-        script = ["importImages", args.images, f"--comment={args.images_comment}"]
+        script = ["importImages", f"--comment={args.images_comment}"]
         if args.search_recursively:
             script.append("--search-recursively")
+        script.extend(["--", args.images])
         scripts.append(script)
 
     if args.xml:

--- a/miraheze/mediawiki/mwimport.py
+++ b/miraheze/mediawiki/mwimport.py
@@ -1,4 +1,4 @@
-#!/hsr/bin/env python3
+#!/usr/bin/env python3
 import argparse
 import os
 import shlex
@@ -100,7 +100,7 @@ def run_scripts(args: argparse.Namespace, scripts: list[list[str]]) -> int:
 
         if not args.nolog:
             print("Logging execution end...")
-            log(f"{shlex.join(script)} (END - exit={proc.returncode}")
+            log(f"{shlex.join(script)} (END - exit={proc.returncode})")
 
         if proc.returncode:
             return proc.returncode

--- a/miraheze/mediawiki/mwimport.py
+++ b/miraheze/mediawiki/mwimport.py
@@ -122,7 +122,7 @@ def run_scripts(args: argparse.Namespace, scripts: list[list[str]]) -> int:  # p
     return 0
 
 
-def run():
+def run():  # pragma: no cover
     try:
         args = parse_args()
     except ValueError as e:
@@ -150,5 +150,5 @@ def run():
     return return_code
 
 
-if __name__ == '__main__':
+if __name__ == '__main__':  # pragma: no cover
     sys.exit(run())

--- a/miraheze/mediawiki/mwimport.py
+++ b/miraheze/mediawiki/mwimport.py
@@ -98,7 +98,7 @@ def get_scripts(args: argparse.Namespace) -> list[list[str]]:
     return scripts
 
 
-def run_scripts(args: argparse.Namespace, scripts: list[list[str]]) -> int:
+def run_scripts(args: argparse.Namespace, scripts: list[list[str]]) -> int:  # pragma: no cover
     for script in scripts:
         print(f'Running {shlex.join(script)}')
         if not args.nolog:

--- a/miraheze/mediawiki/mwimport.py
+++ b/miraheze/mediawiki/mwimport.py
@@ -7,34 +7,34 @@ import sys
 
 
 def parse_args(input_args: list | None = None, check_paths: bool = True) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="A script to automate manual wiki imports")
+    parser = argparse.ArgumentParser(description='A script to automate manual wiki imports')
     parser.add_argument(
-        "--no-log", dest="nolog", action="store_true",
-        help="Whether or not to disable logging to the server admin log",
+        '--no-log', dest='nolog', action='store_true',
+        help='Whether or not to disable logging to the server admin log',
     )
     parser.add_argument(
-        "--confirm", "--yes", "-y", dest="confirm", action="store_true",
-        help="Whether or not to skip the initial confirmation prompt",
+        '--confirm', '--yes', '-y', dest='confirm', action='store_true',
+        help='Whether or not to skip the initial confirmation prompt',
     )
-    parser.add_argument("--version", help="MediaWiki version to use (automatically detected if not passed)")
-    parser.add_argument("--xml", help="XML file to import")
-    parser.add_argument("--username-prefix", help="Interwiki prefix for importing XML")
-    parser.add_argument("--images", help="Directory of images to import")
+    parser.add_argument('--version', help='MediaWiki version to use (automatically detected if not passed)')
+    parser.add_argument('--xml', help='XML file to import')
+    parser.add_argument('--username-prefix', help='Interwiki prefix for importing XML')
+    parser.add_argument('--images', help='Directory of images to import')
     parser.add_argument(
-        "--images-comment", help="The comment passed to importImages.php"
-        " (example: 'Importing images from https://example.com ([[phorge:T1234|T1234]])')",
+        '--images-comment', help='The comment passed to importImages.php'
+        ' (example: "Importing images from https://example.com ([[phorge:T1234|T1234]])")',
     )
     parser.add_argument(
-        "--search-recursively", action="store_true",
-        help="Whether or not to pass --search-recursively (check files in subdirectories) to importImages.php",
+        '--search-recursively', action='store_true',
+        help='Whether or not to pass --search-recursively (check files in subdirectories) to importImages.php',
     )
-    parser.add_argument("wiki", help="Database name of the wiki to import to")
+    parser.add_argument('wiki', help='Database name of the wiki to import to')
 
     args = parser.parse_args(input_args)
     if not args.xml and not args.images:
-        raise ValueError("--xml and/or --images must be passed")
+        raise ValueError('--xml and/or --images must be passed')
     if args.images and not args.images_comment:
-        raise ValueError("--images-comment must be passed when importing images")
+        raise ValueError('--images-comment must be passed when importing images')
 
     # This is honestly only for unit testing as I can't really think of a reason
     # to disable this check in production
@@ -42,23 +42,23 @@ def parse_args(input_args: list | None = None, check_paths: bool = True) -> argp
         # This is not meant to be comprehensive, but just to make sure that someone
         # doesn't typo a path or so
         if args.xml and not os.path.exists(args.xml):
-            raise ValueError(f"Cannot find XML to import: {repr(args.xml)}")
+            raise ValueError(f'Cannot find XML to import: {repr(args.xml)}')
         if args.images and not os.path.exists(args.images):
-            raise ValueError(f"Cannot find images to import: {repr(args.images)}")
+            raise ValueError(f'Cannot find images to import: {repr(args.images)}')
 
     return args
 
 
 def log(message: str):
     subprocess.run(
-        ["/usr/local/bin/logsalmsg", message],
+        ['/usr/local/bin/logsalmsg', message],
         check=True,
     )
 
 
 def get_version(wiki: str) -> str:
     return subprocess.run(
-        ["/usr/local/bin/getMWVersion", wiki],
+        ['/usr/local/bin/getMWVersion', wiki],
         stdout=subprocess.PIPE,
         check=True,
         text=True,
@@ -69,40 +69,40 @@ def get_scripts(args: argparse.Namespace) -> list[list[str]]:
     scripts = []
 
     if args.xml:
-        script = ["importDump", "--no-updates"]
+        script = ['importDump', '--no-updates']
         if args.username_prefix:
-            script.append(f"--username-prefix={args.username_prefix}")
-        script.extend(["--", args.xml])
+            script.append(f'--username-prefix={args.username_prefix}')
+        script.extend(['--', args.xml])
         scripts.append(script)
 
     if args.images:
-        script = ["importImages", f"--comment={args.images_comment}"]
+        script = ['importImages', f'--comment={args.images_comment}']
         if args.search_recursively:
-            script.append("--search-recursively")
-        script.extend(["--", args.images])
+            script.append('--search-recursively')
+        script.extend(['--', args.images])
         scripts.append(script)
 
     if args.xml:
-        scripts.append(["rebuildall"])
-        scripts.append(["initEditCount"])
+        scripts.append(['rebuildall'])
+        scripts.append(['initEditCount'])
 
-    scripts.append(["initSiteStats", "--update"])
+    scripts.append(['initSiteStats', '--update'])
 
     return scripts
 
 
 def run_scripts(args: argparse.Namespace, scripts: list[list[str]]) -> int:
     for script in scripts:
-        print(f"Running {shlex.join(script)}")
+        print(f'Running {shlex.join(script)}')
         if not args.nolog:
-            print("Logging execution...")
+            print('Logging execution...')
             log(shlex.join(script))
 
         proc = subprocess.run(script)
 
         if not args.nolog:
-            print("Logging execution end...")
-            log(f"{shlex.join(script)} (END - exit={proc.returncode})")
+            print('Logging execution end...')
+            log(f'{shlex.join(script)} (END - exit={proc.returncode})')
 
         if proc.returncode:
             return proc.returncode
@@ -114,34 +114,34 @@ def run():
     try:
         args = parse_args()
     except ValueError as e:
-        print(f"{type(e).__name__}: {e}", file=sys.stderr)
+        print(f'{type(e).__name__}: {e}', file=sys.stderr)
         return 1
 
     version = args.version or get_version(args.wiki)
 
     scripts = get_scripts(args)
     scripts = [
-        ["sudo", "-u", "www-data", "php", f"/srv/mediawiki/{version}/maintenance/run.php", f"--wiki={args.wiki}", *script] for script in scripts
+        ['sudo', '-u', 'www-data', 'php', f'/srv/mediawiki/{version}/maintenance/run.php', f'--wiki={args.wiki}', *script] for script in scripts
     ]
 
-    print("Will run:")
+    print('Will run:')
     for script in scripts:
-        print(f"* {shlex.join(script)}")
-    if not args.confirm and input("Type 'Y' to confirm: ").upper() != "Y":
+        print(f'* {shlex.join(script)}')
+    if not args.confirm and input("Type 'Y' to confirm: ").upper() != 'Y':
         return 1
 
     if not args.nolog:
-        print("Logging start...")
-        log(f"Starting import for {args.wiki} (XML: {args.xml}; Images: {args.images})")
+        print('Logging start...')
+        log(f'Starting import for {args.wiki} (XML: {args.xml}; Images: {args.images})')
 
     return_code = run_scripts(args, scripts)
 
     if not args.nolog:
-        print("Logging end...")
-        log(f"Finished import for {args.wiki} (XML: {args.xml}; Images: {args.images}) (END - exit={return_code})")
+        print('Logging end...')
+        log(f'Finished import for {args.wiki} (XML: {args.xml}; Images: {args.images}) (END - exit={return_code})')
 
     return return_code
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     sys.exit(run())

--- a/miraheze/mediawiki/mwimport.py
+++ b/miraheze/mediawiki/mwimport.py
@@ -1,0 +1,131 @@
+#!/hsr/bin/env python3
+import argparse
+import os
+import shlex
+import subprocess
+import sys
+
+def parse_args(args: list | None = None, check_paths: bool = True) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="A script to automate manual wiki imports")
+    parser.add_argument("--no-log", dest="nolog", action="store_true",
+        help="Whether or not to disable logging to the server admin log")
+    parser.add_argument("--confirm", "--yes", "-y", dest="confirm", action="store_true",
+        help="Whether or not to skip the initial confirmation prompt")
+    parser.add_argument("--version", help="MediaWiki version to use (automatically detected if not passed)")
+    parser.add_argument("--xml", help="XML file to import")
+    parser.add_argument("--username-prefix", help="Interwiki prefix for importing XML")
+    parser.add_argument("--images", help="Directory of images to import")
+    parser.add_argument("--images-comment", help="The comment passed to importImages.php"
+        " (example: 'Importing images from https://example.com ([[phorge:T1234|T1234]])')")
+    parser.add_argument("--search-recursively", action="store_true",
+        help="Whether or not to pass --search-recursively (check files in subdirectories) to importImages.php")
+    parser.add_argument("wiki", help="Database name of the wiki to import to")
+
+    args = parser.parse_args(args)
+    if not args.xml and not args.images:
+        raise ValueError("--xml and/or --images must be passed")
+    if args.images and not args.images_comment:
+        raise ValueError("--images-comment must be passed when importing images")
+
+    # This is honestly only for unit testing as I can't really think of a reason
+    # to disable this check in production
+    if check_paths:
+        # This is not meant to be comprehensive, but just to make sure that someone
+        # doesn't typo a path or so
+        if args.xml and not os.path.exists(args.xml):
+            raise ValueError(f"Cannot find XML to import: {repr(args.xml)}")
+        if args.images and not os.path.exists(args.images):
+            raise ValueError(f"Cannot find images to import: {repr(args.images)}")
+
+    return args
+
+def log(message: str):
+    subprocess.run(
+        ["/usr/local/bin/logsalmsg", message],
+        check=True,
+    )
+
+def get_version(wiki: str) -> str:
+    return subprocess.run(
+        ["/usr/local/bin/getMWVersion", wiki],
+        stdout=subprocess.PIPE,
+        check=True,
+        text=True,
+    ).stdout.strip()
+
+def get_scripts(args: argparse.Namespace) -> list[list[str]]:
+    scripts = []
+
+    if args.xml:
+        script = ["importDump", args.xml, "--no-updates"]
+        if args.username_prefix:
+            script.append(f"--username-prefix={args.username_prefix}")
+        scripts.append(script)
+
+    if args.images:
+        script = ["importImages", args.images, f"--comment={args.images_comment}"]
+        if args.search_recursively:
+            script.append("--search-recursively")
+        scripts.append(script)
+
+    if args.xml:
+        scripts.append(["rebuildall"])
+        scripts.append(["initEditCount"])
+
+    scripts.append(["initSiteStats", "--update"])
+
+    return scripts
+
+def run_scripts(args: argparse.Namespace, scripts: list[list[str]]) -> int:
+    for script in scripts:
+        print(f"Running {shlex.join(script)}")
+        if not args.nolog:
+            print("Logging execution...")
+            log(shlex.join(script))
+
+        proc = subprocess.run(script)
+
+        if not args.nolog:
+            print("Logging execution end...")
+            log(f"{shlex.join(script)} (END - exit={proc.returncode}")
+
+        if proc.returncode:
+            return proc.returncode
+
+    return 0
+
+def run():
+    try:
+        args = parse_args()
+    except ValueError as e:
+        print(f"{type(e).__name__}: {e}", file=sys.stderr)
+        return 1
+
+    version = args.version or get_version(args.wiki)
+
+    scripts = get_scripts(args)
+    scripts = [
+        ["sudo", "-u", "www-data", "php", f"/srv/mediawiki/{version}/maintenance/run.php", f"--wiki={args.wiki}", *script] for script in scripts
+    ]
+
+    print("Will run:")
+    for script in scripts:
+        print(f"* {shlex.join(script)}")
+    if not args.confirm:
+        if input("Type 'Y' to confirm: ").upper() != "Y":
+            return 1
+
+    if not args.nolog:
+        print("Logging start...")
+        log(f"Starting import for {args.wiki} (XML: {args.xml}; Images: {args.images})")
+
+    return_code = run_scripts(args, scripts)
+
+    if not args.nolog:
+        print("Logging end...")
+        log(f"Finished import for {args.wiki} (XML: {args.xml}; Images: {args.images}) (END - exit={return_code})")
+
+    return return_code
+
+if __name__ == "__main__":
+    sys.exit(run())

--- a/miraheze/version.py
+++ b/miraheze/version.py
@@ -1,1 +1,1 @@
-VERSION = '0.0.7'
+VERSION = '0.0.8'

--- a/tests/test_mwimport.py
+++ b/tests/test_mwimport.py
@@ -51,39 +51,35 @@ def test_parse_args_username_prefix():
 
 
 def test_parse_args_need_xml_or_images():
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError, match="--xml and/or --images must be passed"):
         mwimport.parse_args([
             "examplewiki",
         ])
-    assert str(excinfo.value) == "--xml and/or --images must be passed"
 
 
 def test_parse_args_images_need_comment():
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError, match="--images-comment must be passed when importing images"):
         mwimport.parse_args([
             "--images=images",
             "examplewiki",
         ])
-    assert str(excinfo.value) == "--images-comment must be passed when importing images"
 
 
 def test_parse_args_missing_xml():
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError, match="Cannot find XML to import: '/dev/no xml'"):
         mwimport.parse_args([
-            "--xml=/dev/no xml?",
+            "--xml=/dev/no xml",
             "examplewiki",
         ])
-    assert str(excinfo.value) == "Cannot find XML to import: '/dev/no xml?'"
 
 
 def test_parse_args_missing_images():
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError, match="Cannot find images to import: '/dev/no images'"):
         mwimport.parse_args([
-            "--images=/dev/no images?",
+            "--images=/dev/no images",
             "--images-comment=Importing from https://example.com",
             "examplewiki",
         ])
-    assert str(excinfo.value) == "Cannot find images to import: '/dev/no images?'"
 
 
 def test_get_scripts_xml_images():

--- a/tests/test_mwimport.py
+++ b/tests/test_mwimport.py
@@ -91,8 +91,8 @@ def test_get_scripts_xml_images():
     ], False)
     scripts = mwimport.get_scripts(args)
     assert scripts == [
-        ["importDump", "dump.xml", "--no-updates"],
-        ["importImages", "images", "--comment=Importing from https://example.com"],
+        ["importDump", "--no-updates", "--", "dump.xml"],
+        ["importImages", "--comment=Importing from https://example.com", "--", "images"],
         ["rebuildall"],
         ["initEditCount"],
         ["initSiteStats", "--update"],
@@ -107,7 +107,7 @@ def test_get_scripts_username_prefix():
     ], False)
     scripts = mwimport.get_scripts(args)
     assert scripts == [
-        ["importDump", "dump.xml", "--no-updates", "--username-prefix=w"],
+        ["importDump", "--no-updates", "--username-prefix=w", "--", "dump.xml"],
         ["rebuildall"],
         ["initEditCount"],
         ["initSiteStats", "--update"],
@@ -123,6 +123,6 @@ def test_get_scripts_search_recursively():
     ], False)
     scripts = mwimport.get_scripts(args)
     assert scripts == [
-        ["importImages", "images", "--comment=Importing from https://example.com", "--search-recursively"],
+        ["importImages", "--comment=Importing from https://example.com", "--search-recursively", "--", "images"],
         ["initSiteStats", "--update"],
     ]

--- a/tests/test_mwimport.py
+++ b/tests/test_mwimport.py
@@ -84,45 +84,60 @@ def test_parse_args_missing_images():
 
 def test_get_scripts_xml_images():
     args = mwimport.parse_args([
+        '--version=0.42',
         '--xml=dump.xml',
         '--images=images',
         '--images-comment=Importing from https://example.com',
         'examplewiki',
     ], False)
     scripts = mwimport.get_scripts(args)
-    assert scripts == [
+    expected = [
         ['importDump', '--no-updates', '--', 'dump.xml'],
         ['importImages', '--comment=Importing from https://example.com', '--', 'images'],
         ['rebuildall'],
         ['initEditCount'],
         ['initSiteStats', '--update'],
     ]
+    expected = [
+        ['sudo', '-u', 'www-data', 'php', '/srv/mediawiki/0.42/maintenance/run.php', script[0], '--wiki=examplewiki', *script[1:]] for script in expected
+    ]
+    assert scripts == expected
 
 
 def test_get_scripts_username_prefix():
     args = mwimport.parse_args([
+        '--version=0.42',
         '--xml=dump.xml',
         '--username-prefix=w',
         'examplewiki',
     ], False)
     scripts = mwimport.get_scripts(args)
-    assert scripts == [
+    expected = [
         ['importDump', '--no-updates', '--username-prefix=w', '--', 'dump.xml'],
         ['rebuildall'],
         ['initEditCount'],
         ['initSiteStats', '--update'],
     ]
+    expected = [
+        ['sudo', '-u', 'www-data', 'php', '/srv/mediawiki/0.42/maintenance/run.php', script[0], '--wiki=examplewiki', *script[1:]] for script in expected
+    ]
+    assert scripts == expected
 
 
 def test_get_scripts_search_recursively():
     args = mwimport.parse_args([
+        '--version=0.42',
         '--images=images',
         '--images-comment=Importing from https://example.com',
         '--search-recursively',
         'examplewiki',
     ], False)
     scripts = mwimport.get_scripts(args)
-    assert scripts == [
+    expected = [
         ['importImages', '--comment=Importing from https://example.com', '--search-recursively', '--', 'images'],
         ['initSiteStats', '--update'],
     ]
+    expected = [
+        ['sudo', '-u', 'www-data', 'php', '/srv/mediawiki/0.42/maintenance/run.php', script[0], '--wiki=examplewiki', *script[1:]] for script in expected
+    ]
+    assert scripts == expected

--- a/tests/test_mwimport.py
+++ b/tests/test_mwimport.py
@@ -66,7 +66,7 @@ def test_parse_args_images_need_comment():
 
 
 def test_parse_args_missing_xml():
-    with pytest.raises(ValueError, match='Cannot find XML to import: '/dev/no xml''):
+    with pytest.raises(ValueError, match="Cannot find XML to import: '/dev/no xml'"):
         mwimport.parse_args([
             '--xml=/dev/no xml',
             'examplewiki',
@@ -74,7 +74,7 @@ def test_parse_args_missing_xml():
 
 
 def test_parse_args_missing_images():
-    with pytest.raises(ValueError, match='Cannot find images to import: '/dev/no images''):
+    with pytest.raises(ValueError, match="Cannot find images to import: '/dev/no images'"):
         mwimport.parse_args([
             '--images=/dev/no images',
             '--images-comment=Importing from https://example.com',

--- a/tests/test_mwimport.py
+++ b/tests/test_mwimport.py
@@ -89,6 +89,7 @@ def test_parse_args_both_xml_images_exists():
         xml = os.path.join(tempdir, 'dump.xml')
         with open(xml, 'w'):
             # Intentionally empty since we just need to create the file, and it being empty can do
+            pass
 
         images = os.path.join(tempdir, 'images')
         os.mkdir(images)

--- a/tests/test_mwimport.py
+++ b/tests/test_mwimport.py
@@ -87,7 +87,8 @@ def test_parse_args_missing_images():
 def test_parse_args_both_xml_images_exists():
     with tempfile.TemporaryDirectory() as tempdir:
         xml = os.path.join(tempdir, 'dump.xml')
-        open(xml, 'w').close()
+        with open(xml, 'w'):
+            # Intentionally empty since we just need to create the file, and it being empty can do
 
         images = os.path.join(tempdir, 'images')
         os.mkdir(images)

--- a/tests/test_mwimport.py
+++ b/tests/test_mwimport.py
@@ -4,125 +4,125 @@ from miraheze.mediawiki import mwimport
 
 def test_parse_args_xml_images():
     args = mwimport.parse_args([
-        "--xml=dump.xml",
-        "--images=images",
-        "--images-comment=Importing from https://example.com",
-        "examplewiki",
+        '--xml=dump.xml',
+        '--images=images',
+        '--images-comment=Importing from https://example.com',
+        'examplewiki',
     ], False)
-    assert args.xml == "dump.xml"
-    assert args.images == "images"
-    assert args.images_comment == "Importing from https://example.com"
-    assert args.wiki == "examplewiki"
+    assert args.xml == 'dump.xml'
+    assert args.images == 'images'
+    assert args.images_comment == 'Importing from https://example.com'
+    assert args.wiki == 'examplewiki'
 
 
 def test_parse_args_images_recursively():
     args = mwimport.parse_args([
-        "--images=images",
-        "--search-recursively",
-        "--images-comment=Importing from https://example.com",
-        "examplewiki",
+        '--images=images',
+        '--search-recursively',
+        '--images-comment=Importing from https://example.com',
+        'examplewiki',
     ], False)
-    assert args.images == "images"
+    assert args.images == 'images'
     assert args.search_recursively
-    assert args.images_comment == "Importing from https://example.com"
-    assert args.wiki == "examplewiki"
+    assert args.images_comment == 'Importing from https://example.com'
+    assert args.wiki == 'examplewiki'
 
 
 def test_parse_args_no_log_and_confirm_and_version():
     args = mwimport.parse_args([
-        "--no-log",
-        "--confirm",
-        "--version=0.42",
-        "--xml=dump.xml",
-        "examplewiki",
+        '--no-log',
+        '--confirm',
+        '--version=0.42',
+        '--xml=dump.xml',
+        'examplewiki',
     ], False)
     assert args.nolog
     assert args.confirm
-    assert args.version == "0.42"
+    assert args.version == '0.42'
 
 
 def test_parse_args_username_prefix():
     args = mwimport.parse_args([
-        "--xml=dump.xml",
-        "--username-prefix=w",
-        "examplewiki",
+        '--xml=dump.xml',
+        '--username-prefix=w',
+        'examplewiki',
     ], False)
-    assert args.username_prefix == "w"
+    assert args.username_prefix == 'w'
 
 
 def test_parse_args_need_xml_or_images():
-    with pytest.raises(ValueError, match="--xml and/or --images must be passed"):
+    with pytest.raises(ValueError, match='--xml and/or --images must be passed'):
         mwimport.parse_args([
-            "examplewiki",
+            'examplewiki',
         ])
 
 
 def test_parse_args_images_need_comment():
-    with pytest.raises(ValueError, match="--images-comment must be passed when importing images"):
+    with pytest.raises(ValueError, match='--images-comment must be passed when importing images'):
         mwimport.parse_args([
-            "--images=images",
-            "examplewiki",
+            '--images=images',
+            'examplewiki',
         ])
 
 
 def test_parse_args_missing_xml():
-    with pytest.raises(ValueError, match="Cannot find XML to import: '/dev/no xml'"):
+    with pytest.raises(ValueError, match='Cannot find XML to import: '/dev/no xml''):
         mwimport.parse_args([
-            "--xml=/dev/no xml",
-            "examplewiki",
+            '--xml=/dev/no xml',
+            'examplewiki',
         ])
 
 
 def test_parse_args_missing_images():
-    with pytest.raises(ValueError, match="Cannot find images to import: '/dev/no images'"):
+    with pytest.raises(ValueError, match='Cannot find images to import: '/dev/no images''):
         mwimport.parse_args([
-            "--images=/dev/no images",
-            "--images-comment=Importing from https://example.com",
-            "examplewiki",
+            '--images=/dev/no images',
+            '--images-comment=Importing from https://example.com',
+            'examplewiki',
         ])
 
 
 def test_get_scripts_xml_images():
     args = mwimport.parse_args([
-        "--xml=dump.xml",
-        "--images=images",
-        "--images-comment=Importing from https://example.com",
-        "examplewiki",
+        '--xml=dump.xml',
+        '--images=images',
+        '--images-comment=Importing from https://example.com',
+        'examplewiki',
     ], False)
     scripts = mwimport.get_scripts(args)
     assert scripts == [
-        ["importDump", "--no-updates", "--", "dump.xml"],
-        ["importImages", "--comment=Importing from https://example.com", "--", "images"],
-        ["rebuildall"],
-        ["initEditCount"],
-        ["initSiteStats", "--update"],
+        ['importDump', '--no-updates', '--', 'dump.xml'],
+        ['importImages', '--comment=Importing from https://example.com', '--', 'images'],
+        ['rebuildall'],
+        ['initEditCount'],
+        ['initSiteStats', '--update'],
     ]
 
 
 def test_get_scripts_username_prefix():
     args = mwimport.parse_args([
-        "--xml=dump.xml",
-        "--username-prefix=w",
-        "examplewiki",
+        '--xml=dump.xml',
+        '--username-prefix=w',
+        'examplewiki',
     ], False)
     scripts = mwimport.get_scripts(args)
     assert scripts == [
-        ["importDump", "--no-updates", "--username-prefix=w", "--", "dump.xml"],
-        ["rebuildall"],
-        ["initEditCount"],
-        ["initSiteStats", "--update"],
+        ['importDump', '--no-updates', '--username-prefix=w', '--', 'dump.xml'],
+        ['rebuildall'],
+        ['initEditCount'],
+        ['initSiteStats', '--update'],
     ]
 
 
 def test_get_scripts_search_recursively():
     args = mwimport.parse_args([
-        "--images=images",
-        "--images-comment=Importing from https://example.com",
-        "--search-recursively",
-        "examplewiki",
+        '--images=images',
+        '--images-comment=Importing from https://example.com',
+        '--search-recursively',
+        'examplewiki',
     ], False)
     scripts = mwimport.get_scripts(args)
     assert scripts == [
-        ["importImages", "--comment=Importing from https://example.com", "--search-recursively", "--", "images"],
-        ["initSiteStats", "--update"],
+        ['importImages', '--comment=Importing from https://example.com', '--search-recursively', '--', 'images'],
+        ['initSiteStats', '--update'],
     ]

--- a/tests/test_mwimport.py
+++ b/tests/test_mwimport.py
@@ -1,0 +1,121 @@
+import pytest
+from miraheze.mediawiki import mwimport
+
+def test_parse_args_xml_images():
+    args = mwimport.parse_args([
+        "--xml=dump.xml",
+        "--images=images",
+        "--images-comment=Importing from https://example.com",
+        "examplewiki",
+    ], False)
+    assert args.xml == "dump.xml"
+    assert args.images == "images"
+    assert args.images_comment == "Importing from https://example.com"
+    assert args.wiki == "examplewiki"
+
+def test_parse_args_images_recursively():
+    args = mwimport.parse_args([
+        "--images=images",
+        "--search-recursively",
+        "--images-comment=Importing from https://example.com",
+        "examplewiki",
+    ], False)
+    assert args.images == "images"
+    assert args.search_recursively
+    assert args.images_comment == "Importing from https://example.com"
+    assert args.wiki == "examplewiki"
+
+def test_parse_args_no_log_and_confirm_and_version():
+    args = mwimport.parse_args([
+        "--no-log",
+        "--confirm",
+        "--version=0.42",
+        "--xml=dump.xml",
+        "examplewiki",
+    ], False)
+    assert args.nolog
+    assert args.confirm
+    assert args.version == "0.42"
+
+def test_parse_args_username_prefix():
+    args = mwimport.parse_args([
+        "--xml=dump.xml",
+        "--username-prefix=w",
+        "examplewiki",
+    ], False)
+    assert args.username_prefix == "w"
+
+def test_parse_args_need_xml_or_images():
+    with pytest.raises(ValueError) as excinfo:
+        mwimport.parse_args([
+            "examplewiki",
+        ])
+    assert str(excinfo.value) == "--xml and/or --images must be passed"
+
+def test_parse_args_images_need_comment():
+    with pytest.raises(ValueError) as excinfo:
+        mwimport.parse_args([
+            "--images=images",
+            "examplewiki",
+        ])
+    assert str(excinfo.value) == "--images-comment must be passed when importing images"
+
+def test_parse_args_missing_xml():
+    with pytest.raises(ValueError) as excinfo:
+        mwimport.parse_args([
+            "--xml=/dev/no xml?",
+            "examplewiki",
+        ])
+    assert str(excinfo.value) == "Cannot find XML to import: '/dev/no xml?'"
+
+def test_parse_args_missing_images():
+    with pytest.raises(ValueError) as excinfo:
+        mwimport.parse_args([
+            "--images=/dev/no images?",
+            "--images-comment=Importing from https://example.com",
+            "examplewiki",
+        ])
+    assert str(excinfo.value) == "Cannot find images to import: '/dev/no images?'"
+
+def test_get_scripts_xml_images():
+    args = mwimport.parse_args([
+        "--xml=dump.xml",
+        "--images=images",
+        "--images-comment=Importing from https://example.com",
+        "examplewiki",
+    ], False)
+    scripts = mwimport.get_scripts(args)
+    assert scripts == [
+        ["importDump", "dump.xml", "--no-updates"],
+        ["importImages", "images", "--comment=Importing from https://example.com"],
+        ["rebuildall"],
+        ["initEditCount"],
+        ["initSiteStats", "--update"],
+    ]
+
+def test_get_scripts_username_prefix():
+    args = mwimport.parse_args([
+        "--xml=dump.xml",
+        "--username-prefix=w",
+        "examplewiki",
+    ], False)
+    scripts = mwimport.get_scripts(args)
+    assert scripts == [
+        ["importDump", "dump.xml", "--no-updates", "--username-prefix=w"],
+        ["rebuildall"],
+        ["initEditCount"],
+        ["initSiteStats", "--update"],
+    ]
+
+def test_get_scripts_search_recursively():
+    args = mwimport.parse_args([
+        "--images=images",
+        "--images-comment=Importing from https://example.com",
+        "--search-recursively",
+        "examplewiki",
+    ], False)
+    scripts = mwimport.get_scripts(args)
+    assert scripts == [
+        ["importImages", "images", "--comment=Importing from https://example.com", "--search-recursively"],
+        ["initSiteStats", "--update"],
+    ]

--- a/tests/test_mwimport.py
+++ b/tests/test_mwimport.py
@@ -1,6 +1,7 @@
 import pytest
 from miraheze.mediawiki import mwimport
 
+
 def test_parse_args_xml_images():
     args = mwimport.parse_args([
         "--xml=dump.xml",
@@ -12,6 +13,7 @@ def test_parse_args_xml_images():
     assert args.images == "images"
     assert args.images_comment == "Importing from https://example.com"
     assert args.wiki == "examplewiki"
+
 
 def test_parse_args_images_recursively():
     args = mwimport.parse_args([
@@ -25,6 +27,7 @@ def test_parse_args_images_recursively():
     assert args.images_comment == "Importing from https://example.com"
     assert args.wiki == "examplewiki"
 
+
 def test_parse_args_no_log_and_confirm_and_version():
     args = mwimport.parse_args([
         "--no-log",
@@ -37,6 +40,7 @@ def test_parse_args_no_log_and_confirm_and_version():
     assert args.confirm
     assert args.version == "0.42"
 
+
 def test_parse_args_username_prefix():
     args = mwimport.parse_args([
         "--xml=dump.xml",
@@ -45,12 +49,14 @@ def test_parse_args_username_prefix():
     ], False)
     assert args.username_prefix == "w"
 
+
 def test_parse_args_need_xml_or_images():
     with pytest.raises(ValueError) as excinfo:
         mwimport.parse_args([
             "examplewiki",
         ])
     assert str(excinfo.value) == "--xml and/or --images must be passed"
+
 
 def test_parse_args_images_need_comment():
     with pytest.raises(ValueError) as excinfo:
@@ -60,6 +66,7 @@ def test_parse_args_images_need_comment():
         ])
     assert str(excinfo.value) == "--images-comment must be passed when importing images"
 
+
 def test_parse_args_missing_xml():
     with pytest.raises(ValueError) as excinfo:
         mwimport.parse_args([
@@ -67,6 +74,7 @@ def test_parse_args_missing_xml():
             "examplewiki",
         ])
     assert str(excinfo.value) == "Cannot find XML to import: '/dev/no xml?'"
+
 
 def test_parse_args_missing_images():
     with pytest.raises(ValueError) as excinfo:
@@ -76,6 +84,7 @@ def test_parse_args_missing_images():
             "examplewiki",
         ])
     assert str(excinfo.value) == "Cannot find images to import: '/dev/no images?'"
+
 
 def test_get_scripts_xml_images():
     args = mwimport.parse_args([
@@ -93,6 +102,7 @@ def test_get_scripts_xml_images():
         ["initSiteStats", "--update"],
     ]
 
+
 def test_get_scripts_username_prefix():
     args = mwimport.parse_args([
         "--xml=dump.xml",
@@ -106,6 +116,7 @@ def test_get_scripts_username_prefix():
         ["initEditCount"],
         ["initSiteStats", "--update"],
     ]
+
 
 def test_get_scripts_search_recursively():
     args = mwimport.parse_args([

--- a/tests/test_mwimport.py
+++ b/tests/test_mwimport.py
@@ -1,3 +1,5 @@
+import os
+import tempfile
 import pytest
 from miraheze.mediawiki import mwimport
 
@@ -80,6 +82,25 @@ def test_parse_args_missing_images():
             '--images-comment=Importing from https://example.com',
             'examplewiki',
         ])
+
+
+def test_parse_args_both_xml_images_exists():
+    with tempfile.TemporaryDirectory() as tempdir:
+        xml = os.path.join(tempdir, 'dump.xml')
+        open(xml, 'w').close()
+
+        images = os.path.join(tempdir, 'images')
+        os.mkdir(images)
+
+        args = mwimport.parse_args([
+            f'--xml={xml}',
+            f'--images={images}',
+            '--images-comment=Importing from https://example.com',
+            'examplewiki',
+        ])
+
+    assert args.xml == xml
+    assert args.images == images
 
 
 def test_get_scripts_xml_images():


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an automated command-line tool to import content into a MediaWiki instance, offering flexible options for XML and image imports with robust parameter checks, logging, and confirmation prompts.
  - Updated the software version to 0.0.8.

- **Tests**
  - Added a comprehensive test suite to verify input handling and command execution across various scenarios, ensuring the new tool performs reliably under different conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->