### PR TITLE
Use RebuildExtensionListCache from ManageWiki

### DIFF
--- a/miraheze/mediawiki/mwdeploy.py
+++ b/miraheze/mediawiki/mwdeploy.py
@@ -554,7 +554,7 @@ def run_process(args: argparse.Namespace, version: str = '') -> list[int]:  # pr
                 rsync.append(_construct_rsync_command(time=args.ignore_time, location=f'/srv/mediawiki-staging/{folder}/*', dest=f'/srv/mediawiki/{folder}/'))
 
         if args.extension_list and version:  # when adding skins/exts
-            rebuild.append(f'sudo -u {DEPLOYUSER} php {runner}CreateWiki:RebuildExtensionListCache --wiki={envinfo["wikidbname"]} --cachedir=/srv/mediawiki/cache/{version}')
+            rebuild.append(f'sudo -u {DEPLOYUSER} php {runner}ManageWiki:RebuildExtensionListCache --wiki={envinfo["wikidbname"]} --cachedir=/srv/mediawiki/cache/{version}')
 
         for cmd in rsync:  # move staged content to live
             exitcodes.append(run_command(cmd))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected the maintenance task used when rebuilding the extension list cache during versioned extension/skin upgrades, improving compatibility and ensuring caches refresh as expected.
  - No user-facing behaviour changes are expected; this enhances backend stability during upgrade operations and reduces the risk of cache inconsistencies.
  - This helps ensure extensions and skins reflect updated configurations promptly after upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->